### PR TITLE
Add fastboot monitoring with battery status display

### DIFF
--- a/cmd/tensor-usbdl/main.go
+++ b/cmd/tensor-usbdl/main.go
@@ -875,6 +875,10 @@ func checkBatteryStatus(log *logger.Logger, fb *tensorutils.Fastboot, voltage st
 
 // formatWithComma formats an integer with comma separators
 func formatWithComma(n int) string {
+	// Handle negative numbers
+	if n < 0 {
+		return "-" + formatWithComma(-n)
+	}
 	s := fmt.Sprintf("%d", n)
 	if len(s) <= 3 {
 		return s

--- a/cmd/tensor-usbdl/main.go
+++ b/cmd/tensor-usbdl/main.go
@@ -209,14 +209,15 @@ func main() {
 	log = logger.NewLogger(app, 2)
 
 	// If --fastboot is specified, skip EUB and go directly to fastboot monitoring
+	// After fastboot monitoring returns, fall through to normal EUB flow
 	if testFastboot {
 		if fastbootSerial != "" {
 			log.Infof("Testing fastboot mode with serial: %s", fastbootSerial)
 		} else {
 			log.Infoln("Testing fastboot mode (auto-detecting device)")
 		}
-		monitorFastboot(log, fastbootSerial, false) // false = don't wait 60 seconds
-		return
+		monitorFastboot(log, fastbootSerial, true) // true = wait for device
+		log.Infoln("Fastboot monitoring complete, continuing to EUB mode...")
 	}
 
 	if header <= 0 {
@@ -593,10 +594,10 @@ func main() {
 
 		// Monitor fastboot if BL3B was sent
 		if bl3bSent {
-			// First, scan for EUB reconnection for 60 seconds
-			log.Infoln("Scanning for EUB reconnection (60 seconds)...")
+			// First, scan for EUB reconnection for 30 seconds
+			log.Infoln("Scanning for EUB reconnection (30 seconds)...")
 			eubFound := false
-			for i := 0; i < 20; i++ { // 20 checks * 3 seconds = 60 seconds
+			for i := 0; i < 10; i++ { // 10 checks * 3 seconds = 30 seconds
 				time.Sleep(3 * time.Second)
 				testDnw, err := tensorutils.GetDNW()
 				if err == nil {
@@ -654,6 +655,7 @@ func monitorFastboot(log *logger.Logger, serial string, waitFirst bool) {
 		}
 
 		// On first connection, display full device info
+		isFirstConnection := firstConnection
 		if firstConnection {
 			log.Infoln("=== Fastboot Device Info ===")
 			displayFastbootInfo(log, fb)
@@ -666,18 +668,90 @@ func monitorFastboot(log *logger.Logger, serial string, waitFirst bool) {
 
 		if vErr != nil {
 			log.Tracef("Failed to get battery voltage: %v", vErr)
-		} else {
-			checkBatteryVoltage(log, voltage, current)
 		}
-
 		if cErr != nil {
 			log.Tracef("Failed to get battery current: %v", cErr)
-		} else {
-			checkBatteryCurrent(log, current)
+		}
+		if vErr == nil || cErr == nil {
+			checkBatteryStatus(log, fb, voltage, current, isFirstConnection)
+		}
+
+		// Check if charging has stopped (battery full or not charging)
+		// Small negative values like -7mA also indicate charging stopped
+		if cErr == nil {
+			mA := parseCurrentMA(current)
+			if mA > -15 && mA < 50 {
+				// Check device state - if not "error", unbricking worked
+				deviceState, sErr := fb.GetVar("device-state")
+				if sErr == nil && deviceState != "error" {
+					log.Infoln("Charging complete - device state is not error, unbricking successful!")
+
+					// Check if already unlocked
+					unlocked, uErr := fb.GetVar("unlocked")
+					if uErr == nil && unlocked == "yes" {
+						log.Infoln("Device is already unlocked - you can flash normally")
+					} else {
+						log.Infoln("Attempting to send unlock command...")
+						// Try flashing unlock first (Pixel standard), then oem unlock
+						if err := fb.FlashingUnlock(); err != nil {
+							log.Warnf("flashing unlock failed, trying oem unlock: %v", err)
+							if _, err := fb.OemCommand("unlock"); err != nil {
+								log.Warnf("oem unlock also failed (may need manual confirmation): %v", err)
+							}
+						}
+						log.Infoln("You can now flash your device normally")
+					}
+					fb.Close()
+					return
+				}
+
+				log.Infoln("Charging complete or stopped - powering off device to return to EUB mode")
+				// Try multiple shutdown methods
+				// Note: powerdown causes device to hang, skip it
+				// log.Infoln("Trying powerdown...")
+				// fb.PowerOff()
+				// log.Infoln("Waiting for device to power off...")
+				// time.Sleep(3 * time.Second)
+
+				// Try reboot first
+				log.Infoln("Trying reboot...")
+				if err := fb.Reboot(); err != nil {
+					log.Warnf("Reboot command failed: %v", err)
+				}
+				time.Sleep(3 * time.Second)
+
+				// Check if device is still connected
+				log.Infoln("Checking if device disconnected...")
+				time.Sleep(1 * time.Second)
+				if _, err := fb.GetVarWithTimeout("product", 1*time.Second); err == nil {
+					fb.Close()
+					log.Warnln("Auto power-off failed. Please manually:")
+					log.Warnln("  1. Disconnect the phone from USB")
+					log.Warnln("  2. Hold power button to power off the device")
+					log.Warnln("  3. Reconnect the phone to USB")
+					log.Infoln("Waiting for device to disconnect...")
+					for {
+						time.Sleep(1 * time.Minute)
+						testFb, err := tensorutils.GetFastboot(serial)
+						if err != nil {
+							break // Device disconnected
+						}
+						// Show battery status while waiting
+						voltage, _ := testFb.GetVar("battery-voltage")
+						current, _ := testFb.GetVar("battery-current")
+						checkBatteryStatus(log, testFb, voltage, current, false)
+						testFb.Close()
+					}
+					log.Infoln("Device disconnected, continuing to EUB mode...")
+				} else {
+					fb.Close()
+				}
+				return
+			}
 		}
 
 		fb.Close()
-		time.Sleep(5 * time.Minute)
+		time.Sleep(1 * time.Minute)
 
 		// Reconnect for next check
 		fb, err = tensorutils.GetFastboot(serial)
@@ -707,7 +781,7 @@ func displayFastbootInfo(log *logger.Logger, fb *tensorutils.Fastboot) {
 		log.Infof("Serial number: %s", val)
 	}
 	if speed := fb.GetSpeed(); speed != "" {
-		log.Infof("USB speed: %s", speed)
+		log.Infof("USB speed: %s", formatUSBSpeed(speed))
 	}
 
 	// Security state
@@ -751,42 +825,51 @@ func displayFastbootInfo(log *logger.Logger, fb *tensorutils.Fastboot) {
 
 	// Battery info
 	if val, err := fb.GetVar("battery-voltage"); err == nil {
-		log.Infof("Battery voltage: %s", val)
+		mV := parseVoltage(val)
+		log.Infof("Battery voltage: %smV", formatWithComma(mV))
 	}
 	if val, err := fb.GetVar("battery-current"); err == nil {
-		log.Infof("Battery current: %s", val)
+		mA := parseCurrentMA(val)
+		log.Infof("Battery current: %smA", formatWithComma(mA))
 	}
 
 	log.Infoln("============================")
 }
 
-// checkBatteryVoltage parses voltage string and warns if below 4200mV
-func checkBatteryVoltage(log *logger.Logger, voltage string, current string) {
-	// Parse voltage like "4292 mV" or "4292mV"
-	voltage = strings.TrimSpace(voltage)
-	voltage = strings.TrimSuffix(voltage, " mV")
-	voltage = strings.TrimSuffix(voltage, "mV")
+// checkBatteryStatus displays combined battery voltage and current status
+func checkBatteryStatus(log *logger.Logger, fb *tensorutils.Fastboot, voltage string, current string, isFirstConnection bool) {
+	mV := parseVoltage(voltage)
+	mA := parseCurrentMA(current)
 
-	// Parse current to check charging rate
-	currentStr := strings.TrimSpace(current)
-	currentStr = strings.TrimSuffix(currentStr, " mA")
-	currentStr = strings.TrimSuffix(currentStr, "mA")
-	var mA int
-	fmt.Sscanf(currentStr, "%d", &mA)
+	fmtV := formatWithComma(mV)
+	fmtA := formatWithComma(mA)
 
-	var mV int
-	if _, err := fmt.Sscanf(voltage, "%d", &mV); err == nil {
-		formatted := formatWithComma(mV)
-		if mV < 4200 {
-			log.Warnf("Battery at %smV - keep waiting, need at least 4,200mV for stable boot", formatted)
-			if mA < 600 {
-				log.Warnf("Charging slowly at %dmA - try a USB-C port or different cable for faster charging", mA)
+	// Determine status message based on voltage and current
+	if mA < 0 {
+		// Discharging
+		log.Warnf("Battery: %smV @ %smA - DISCHARGING! Try a different USB port/cable", fmtV, fmtA)
+		if isFirstConnection && fb != nil {
+			log.Infoln("Attempting USB reset to restart charging...")
+			if err := fb.Reset(); err != nil {
+				log.Warnf("USB reset failed: %v", err)
+				log.Warnf("TIP: Try unplugging and replugging the device manually")
+			} else {
+				log.Infoln("USB reset sent - charging should start soon")
 			}
-		} else if mA < 500 {
-			log.Infof("Battery at %smV - sufficient for boot (full charge may take up to 24 hours)", formatted)
-		} else {
-			log.Infof("Battery at %smV - sufficient for boot (charging well, keep waiting for full charge)", formatted)
 		}
+	} else if mV < 4200 {
+		// Need more charge
+		if mA < 600 {
+			log.Warnf("Battery: %smV @ %smA - need 4,200mV, charging slowly, try USB-C port", fmtV, fmtA)
+		} else {
+			log.Warnf("Battery: %smV @ %smA - need at least 4,200mV for stable boot", fmtV, fmtA)
+		}
+	} else if mA < 500 {
+		// Sufficient but charging slowly
+		log.Infof("Battery: %smV @ %smA - charging slowly, full charge may take up to 24 hours", fmtV, fmtA)
+	} else {
+		// Charging well
+		log.Infof("Battery: %smV @ %smA - charging well, keep waiting for full charge", fmtV, fmtA)
 	}
 }
 
@@ -800,21 +883,42 @@ func formatWithComma(n int) string {
 	return s[:len(s)-3] + "," + s[len(s)-3:]
 }
 
-// checkBatteryCurrent parses current string and warns if negative (discharging)
-func checkBatteryCurrent(log *logger.Logger, current string) {
-	// Parse current like "-106 mA" or "250mA"
+// parseCurrentMA extracts the current value in mA from a string like "319 mA" or "-106mA"
+func parseCurrentMA(current string) int {
 	current = strings.TrimSpace(current)
 	current = strings.TrimSuffix(current, " mA")
 	current = strings.TrimSuffix(current, "mA")
-
 	var mA int
-	if _, err := fmt.Sscanf(current, "%d", &mA); err == nil {
-		if mA < 0 {
-			log.Warnf("Battery current: %dmA - DISCHARGING! Device not charging properly, try a different USB port/cable", mA)
-		} else if mA == 0 {
-			log.Infof("Battery current: %dmA - not charging", mA)
-		} else {
-			log.Infof("Battery current: %dmA - charging", mA)
-		}
+	fmt.Sscanf(current, "%d", &mA)
+	return mA
+}
+
+// parseVoltage extracts the voltage value in mV from a string like "4302 mV" or "4302mV"
+func parseVoltage(voltage string) int {
+	voltage = strings.TrimSpace(voltage)
+	voltage = strings.TrimSuffix(voltage, " mV")
+	voltage = strings.TrimSuffix(voltage, "mV")
+	var mV int
+	fmt.Sscanf(voltage, "%d", &mV)
+	return mV
+}
+
+// formatUSBSpeed converts gousb speed string to human-readable format with max charge rate
+func formatUSBSpeed(speed string) string {
+	switch strings.ToLower(speed) {
+	case "low":
+		return "USB 1.0 Low Speed (1.5 Mbps, max 100mA)"
+	case "full":
+		return "USB 1.1 Full Speed (12 Mbps, max 100mA)"
+	case "high":
+		return "USB 2.0 High Speed (480 Mbps, max 500mA)"
+	case "super":
+		return "USB 3.0 SuperSpeed (5 Gbps, max 900mA)"
+	case "superplus":
+		return "USB 3.1 SuperSpeed+ (10 Gbps, max 900mA)"
+	case "superspeedplus":
+		return "USB 3.1 SuperSpeed+ (10 Gbps, max 900mA)"
+	default:
+		return speed
 	}
 }

--- a/cmd/tensor-usbdl/main.go
+++ b/cmd/tensor-usbdl/main.go
@@ -673,7 +673,7 @@ func monitorFastboot(log *logger.Logger, serial string, waitFirst bool) {
 			log.Tracef("Failed to get battery current: %v", cErr)
 		}
 		if vErr == nil || cErr == nil {
-			checkBatteryStatus(log, fb, voltage, current, isFirstConnection)
+			checkBatteryStatus(log, voltage, current, isFirstConnection)
 		}
 
 		// Check if charging has stopped (battery full or not charging)
@@ -739,7 +739,7 @@ func monitorFastboot(log *logger.Logger, serial string, waitFirst bool) {
 						// Show battery status while waiting
 						voltage, _ := testFb.GetVar("battery-voltage")
 						current, _ := testFb.GetVar("battery-current")
-						checkBatteryStatus(log, testFb, voltage, current, false)
+						checkBatteryStatus(log, voltage, current, false)
 						testFb.Close()
 					}
 					log.Infoln("Device disconnected, continuing to EUB mode...")
@@ -805,8 +805,11 @@ func displayFastbootInfo(log *logger.Logger, fb *tensorutils.Fastboot) {
 	}
 
 	// Hardware info
-	if val, err := fb.GetVar("dram-manufacturer"); err == nil {
-		log.Infof("DRAM: %s", val)
+	ddrManu, _ := fb.GetVar("ddr-manu")
+	ddrSize, _ := fb.GetVar("ddr-size")
+	ddrType, _ := fb.GetVar("ddr-type")
+	if ddrManu != "" || ddrSize != "" || ddrType != "" {
+		log.Infof("DRAM: %s %s %s", ddrManu, ddrType, ddrSize)
 	}
 	if val, err := fb.GetVar("ufs-manufacturer"); err == nil {
 		log.Infof("UFS: %s", val)
@@ -837,7 +840,7 @@ func displayFastbootInfo(log *logger.Logger, fb *tensorutils.Fastboot) {
 }
 
 // checkBatteryStatus displays combined battery voltage and current status
-func checkBatteryStatus(log *logger.Logger, fb *tensorutils.Fastboot, voltage string, current string, isFirstConnection bool) {
+func checkBatteryStatus(log *logger.Logger, voltage string, current string, isFirstConnection bool) {
 	mV := parseVoltage(voltage)
 	mA := parseCurrentMA(current)
 
@@ -846,16 +849,10 @@ func checkBatteryStatus(log *logger.Logger, fb *tensorutils.Fastboot, voltage st
 
 	// Determine status message based on voltage and current
 	if mA < 0 {
-		// Discharging
-		log.Warnf("Battery: %smV @ %smA - DISCHARGING! Try a different USB port/cable", fmtV, fmtA)
-		if isFirstConnection && fb != nil {
-			log.Infoln("Attempting USB reset to restart charging...")
-			if err := fb.Reset(); err != nil {
-				log.Warnf("USB reset failed: %v", err)
-				log.Warnf("TIP: Try unplugging and replugging the device manually")
-			} else {
-				log.Infoln("USB reset sent - charging should start soon")
-			}
+		// Discharging - device is not charging properly
+		log.Warnf("Battery: %smV @ %smA - DISCHARGING!", fmtV, fmtA)
+		if isFirstConnection {
+			log.Warnf(">>> UNPLUG AND REPLUG the USB cable to restart charging <<<")
 		}
 	} else if mV < 4200 {
 		// Need more charge

--- a/cmd/tensor-usbdl/main.go
+++ b/cmd/tensor-usbdl/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -57,11 +58,13 @@ var (
 )
 
 var (
-	help    = false
-	useDNW  = false
-	bitUSB  = false
-	fuzzDPM = false
-	stop    = false
+	help         = false
+	useDNW       = false
+	bitUSB       = false
+	fuzzDPM      = false
+	stop         = false
+	testFastboot = false
+	fastbootSerial = ""
 
 	src         = "sources"
 	factory     = "bootloader.img"
@@ -140,7 +143,9 @@ func usage() {
 			" --dnw         | none   | Overrides the download address (or command) to %X\n"+
 			" --usb         | none   | Sets the 1040th byte to 01 if it is 00\n"+
 			" --fuzzdpm     | none   | (DANGEROUS!) Fuzzes an empty DPM image with random data\n"+
-			" --stop        | none   | Sends the DNW STOP command to the device upon connection\n",
+			" --stop        | none   | Sends the DNW STOP command to the device upon connection\n"+
+			" --fastboot    | none   | Skip EUB and monitor fastboot device directly\n"+
+			" --serial      | string | Specify fastboot device serial (auto-detects if omitted)\n",
 		src, factory, ota,
 		prog,
 		src, factory, ota,
@@ -150,8 +155,17 @@ func usage() {
 	fmt.Fprintf(os.Stderr, "%s\n", text)
 }
 
+func checkRootPrivileges() {
+	if runtime.GOOS == "linux" && os.Geteuid() != 0 {
+		fmt.Fprintln(os.Stderr, "Error: This program requires root privileges on Linux.")
+		fmt.Fprintln(os.Stderr, "Please run with: sudo ./tensor-usbdl [options]")
+		os.Exit(1)
+	}
+}
+
 func main() {
 	fmt.Printf("%s %s - %s\n", app, ver, dev)
+	checkRootPrivileges()
 
 	pflag.Usage = usage
 	pflag.CommandLine.SortFlags = false
@@ -160,6 +174,8 @@ func main() {
 	pflag.BoolVar(&bitUSB, "usb", false, "")
 	pflag.BoolVar(&fuzzDPM, "fuzzdpm", false, "")
 	pflag.BoolVar(&stop, "stop", false, "")
+	pflag.BoolVar(&testFastboot, "fastboot", false, "")
+	pflag.StringVar(&fastbootSerial, "serial", "", "")
 	pflag.StringVarP(&src, "src", "i", src, "")
 	pflag.StringVarP(&factory, "factory", "f", factory, "")
 	pflag.StringVarP(&ota, "ota", "o", ota, "")
@@ -191,6 +207,17 @@ func main() {
 	}
 
 	log = logger.NewLogger(app, 2)
+
+	// If --fastboot is specified, skip EUB and go directly to fastboot monitoring
+	if testFastboot {
+		if fastbootSerial != "" {
+			log.Infof("Testing fastboot mode with serial: %s", fastbootSerial)
+		} else {
+			log.Infoln("Testing fastboot mode (auto-detecting device)")
+		}
+		monitorFastboot(log, fastbootSerial, false) // false = don't wait 60 seconds
+		return
+	}
 
 	if header <= 0 {
 		log.Errorln("[!] Header size must be positive number!")
@@ -335,6 +362,46 @@ func main() {
 
 		request := ""
 		upload := false
+		bl3bSent := false
+		var bl3bSentTime time.Time
+		bl3bWarningShown := false
+
+		// Start background keepalive goroutine with countdown
+		keepaliveDone := make(chan struct{})
+		go func() {
+			ticker := time.NewTicker(60 * time.Second)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-keepaliveDone:
+					return
+				case <-ticker.C:
+					if dnw.Closed() {
+						continue
+					}
+					dnw.Keepalive()
+
+					if bl3bSent {
+						elapsed := time.Since(bl3bSentTime)
+						remaining := 30*time.Minute - elapsed
+						if remaining > 0 {
+							mins := int(remaining.Minutes())
+							secs := int(remaining.Seconds()) % 60
+							log.Infof("Estimated time to fastboot: ~%02d:%02d", mins, secs)
+						} else {
+							log.Infoln("Device expected to reboot to fastboot soon...")
+						}
+					} else {
+						elapsed := time.Since(timeStart)
+						if elapsed > 5*time.Minute && !bl3bWarningShown {
+							log.Warnln("BL3B not reached after 5 minutes - consider restarting the process")
+							bl3bWarningShown = true
+						}
+					}
+				}
+			}
+		}()
+
 		for {
 			if dnw.Closed() {
 				break
@@ -454,6 +521,11 @@ func main() {
 					upload = true
 				case "ack":
 					log.Debugln("Acknowledged", bootloader)
+					if bootloader == "BL3B" && !bl3bSent {
+						bl3bSent = true
+						bl3bSentTime = time.Now()
+						log.Infoln("BL3B sent - waiting for battery charge and fastboot (typically 30 minutes, may take longer)...")
+					}
 					upload = true
 				case "nak":
 					log.Errorln("Refused", bootloader)
@@ -498,6 +570,12 @@ func main() {
 			}
 		}
 
+		// Stop keepalive goroutine
+		close(keepaliveDone)
+
+		// Store serial before closing
+		deviceSerial := dnw.GetSerial()
+
 		if dnw.Closed() {
 			log.Infoln("Device disconnected!")
 		} else {
@@ -513,5 +591,72 @@ func main() {
 		dnw.Free()
 
 		log.Traceln("Connection lasted", time.Since(timeStart).String())
+
+		// Monitor fastboot if BL3B was sent
+		if bl3bSent {
+			monitorFastboot(log, deviceSerial, true) // true = wait 60 seconds first
+		}
+	}
+}
+
+// monitorFastboot polls the device in fastboot mode for battery and unlock status
+func monitorFastboot(log *logger.Logger, serial string, waitFirst bool) {
+	if waitFirst {
+		log.Infoln("Waiting 60 seconds for device to enter fastboot...")
+		time.Sleep(60 * time.Second)
+	}
+
+	for {
+		// Try to connect to fastboot device
+		fb, err := tensorutils.GetFastboot(serial)
+		if err != nil {
+			log.Infoln("Device not found in fastboot mode - returning to EUB scan")
+			return
+		}
+
+		// Check if flashing is in progress (device unresponsive)
+		if fb.IsFlashing() {
+			log.Infoln("Flashing detected - exiting to allow flash to complete")
+			fb.Close()
+			return
+		}
+
+		// Get battery voltage
+		voltage, err := fb.GetVar("battery-voltage")
+		if err != nil {
+			log.Tracef("Failed to get battery voltage: %v", err)
+		} else {
+			log.Infof("Battery voltage: %s", voltage)
+			// Parse voltage and check if below threshold
+			checkBatteryVoltage(log, voltage)
+		}
+
+		// Get unlock status
+		unlocked, err := fb.GetVar("unlocked")
+		if err != nil {
+			log.Tracef("Failed to get unlock status: %v", err)
+		} else {
+			log.Infof("Unlock status: %s", unlocked)
+		}
+
+		fb.Close()
+		time.Sleep(5 * time.Minute)
+	}
+}
+
+// checkBatteryVoltage parses voltage string and warns if below 4200mV
+func checkBatteryVoltage(log *logger.Logger, voltage string) {
+	// Parse voltage like "4292 mV" or "4292mV"
+	voltage = strings.TrimSpace(voltage)
+	voltage = strings.TrimSuffix(voltage, " mV")
+	voltage = strings.TrimSuffix(voltage, "mV")
+
+	var mV int
+	if _, err := fmt.Sscanf(voltage, "%d", &mV); err == nil {
+		if mV < 4200 {
+			log.Warnf("Battery at %dmV - keep waiting, need at least 4200mV for stable boot", mV)
+		} else {
+			log.Infof("Battery at %dmV - sufficient for boot (full charge may take up to 24 hours)", mV)
+		}
 	}
 }

--- a/cmd/tensor-usbdl/main.go
+++ b/cmd/tensor-usbdl/main.go
@@ -385,9 +385,8 @@ func main() {
 						elapsed := time.Since(bl3bSentTime)
 						remaining := 30*time.Minute - elapsed
 						if remaining > 0 {
-							mins := int(remaining.Minutes())
-							secs := int(remaining.Seconds()) % 60
-							log.Infof("Estimated time to fastboot: ~%02d:%02d", mins, secs)
+							mins := int(remaining.Minutes()) + 1 // Round up
+							log.Infof("Estimated time to fastboot: ~%d minutes", mins)
 						} else {
 							log.Infoln("Device expected to reboot to fastboot soon...")
 						}
@@ -594,7 +593,24 @@ func main() {
 
 		// Monitor fastboot if BL3B was sent
 		if bl3bSent {
-			monitorFastboot(log, deviceSerial, true) // true = wait 60 seconds first
+			// First, scan for EUB reconnection for 60 seconds
+			log.Infoln("Scanning for EUB reconnection (60 seconds)...")
+			eubFound := false
+			for i := 0; i < 20; i++ { // 20 checks * 3 seconds = 60 seconds
+				time.Sleep(3 * time.Second)
+				testDnw, err := tensorutils.GetDNW()
+				if err == nil {
+					log.Infoln("Device reconnected to EUB mode")
+					testDnw.Close()
+					eubFound = true
+					break
+				}
+			}
+
+			// If no EUB reconnection, switch to fastboot scanning
+			if !eubFound {
+				monitorFastboot(log, deviceSerial, false)
+			}
 		}
 	}
 }
@@ -602,23 +618,46 @@ func main() {
 // monitorFastboot polls the device in fastboot mode for battery and unlock status
 func monitorFastboot(log *logger.Logger, serial string, waitFirst bool) {
 	if waitFirst {
-		log.Infoln("Waiting 60 seconds for device to enter fastboot...")
-		time.Sleep(60 * time.Second)
+		log.Infoln("Waiting for device to enter fastboot (up to 10 minutes)...")
 	}
 
-	for {
-		// Try to connect to fastboot device
-		fb, err := tensorutils.GetFastboot(serial)
-		if err != nil {
-			log.Infoln("Device not found in fastboot mode - returning to EUB scan")
-			return
-		}
+	// Wait up to 10 minutes for fastboot device to appear, checking every 30 seconds
+	var fb *tensorutils.Fastboot
+	var err error
+	maxWait := 10 * time.Minute
+	checkInterval := 30 * time.Second
+	waited := time.Duration(0)
 
+	for waited < maxWait {
+		fb, err = tensorutils.GetFastboot(serial)
+		if err == nil {
+			break // Found device
+		}
+		time.Sleep(checkInterval)
+		waited += checkInterval
+	}
+
+	if fb == nil {
+		log.Infoln("Device not found in fastboot mode after 10 minutes - returning to EUB scan")
+		return
+	}
+
+	log.Infoln("Device found in fastboot mode")
+
+	firstConnection := true
+	for {
 		// Check if flashing is in progress (device unresponsive)
 		if fb.IsFlashing() {
 			log.Infoln("Flashing detected - exiting to allow flash to complete")
 			fb.Close()
 			return
+		}
+
+		// On first connection, display full device info
+		if firstConnection {
+			log.Infoln("=== Fastboot Device Info ===")
+			displayFastbootInfo(log, fb)
+			firstConnection = false
 		}
 
 		// Get battery voltage
@@ -641,7 +680,75 @@ func monitorFastboot(log *logger.Logger, serial string, waitFirst bool) {
 
 		fb.Close()
 		time.Sleep(5 * time.Minute)
+
+		// Reconnect for next check
+		fb, err = tensorutils.GetFastboot(serial)
+		if err != nil {
+			log.Infoln("Device disconnected from fastboot - returning to EUB scan")
+			return
+		}
 	}
+}
+
+// displayFastbootInfo queries and displays device information from fastboot
+func displayFastbootInfo(log *logger.Logger, fb *tensorutils.Fastboot) {
+	// Device identification
+	if val, err := fb.GetVar("product"); err == nil {
+		log.Infof("Product: %s", val)
+	}
+	if val, err := fb.GetVar("hw-revision"); err == nil {
+		log.Infof("Product revision: %s", val)
+	}
+	if val, err := fb.GetVar("version-bootloader"); err == nil {
+		log.Infof("Bootloader version: %s", val)
+	}
+	if val, err := fb.GetVar("version-baseband"); err == nil {
+		log.Infof("Baseband version: %s", val)
+	}
+	if val, err := fb.GetVar("serialno"); err == nil {
+		log.Infof("Serial number: %s", val)
+	}
+
+	// Security state
+	if val, err := fb.GetVar("secure"); err == nil {
+		log.Infof("Secure boot: %s", val)
+	}
+	if val, err := fb.GetVar("nos-production"); err == nil {
+		log.Infof("NOS production: %s", val)
+	}
+	if val, err := fb.GetVar("unlocked"); err == nil {
+		log.Infof("Device state: %s", val)
+	}
+
+	// GSC (Titan M) version
+	if responses, err := fb.OemCommand("gsc version"); err == nil {
+		for _, line := range responses {
+			log.Infof("GSC: %s", strings.TrimSpace(line))
+		}
+	} else {
+		log.Tracef("GSC version: %v", err)
+	}
+
+	// Hardware info
+	if val, err := fb.GetVar("dram-manufacturer"); err == nil {
+		log.Infof("DRAM: %s", val)
+	}
+	if val, err := fb.GetVar("ufs-manufacturer"); err == nil {
+		log.Infof("UFS: %s", val)
+	}
+
+	// Boot info
+	if val, err := fb.GetVar("current-slot"); err == nil {
+		log.Infof("Boot slot: %s", val)
+	}
+	if val, err := fb.GetVar("reason"); err == nil {
+		log.Infof("Enter reason: %s", val)
+	}
+	if val, err := fb.GetVar("uart"); err == nil {
+		log.Infof("UART: %s", val)
+	}
+
+	log.Infoln("============================")
 }
 
 // checkBatteryVoltage parses voltage string and warns if below 4200mV

--- a/cmd/tensor-usbdl/main.go
+++ b/cmd/tensor-usbdl/main.go
@@ -660,22 +660,20 @@ func monitorFastboot(log *logger.Logger, serial string, waitFirst bool) {
 			firstConnection = false
 		}
 
-		// Get battery voltage
-		voltage, err := fb.GetVar("battery-voltage")
-		if err != nil {
-			log.Tracef("Failed to get battery voltage: %v", err)
+		// Get battery voltage and current
+		voltage, vErr := fb.GetVar("battery-voltage")
+		current, cErr := fb.GetVar("battery-current")
+
+		if vErr != nil {
+			log.Tracef("Failed to get battery voltage: %v", vErr)
 		} else {
-			log.Infof("Battery voltage: %s", voltage)
-			// Parse voltage and check if below threshold
-			checkBatteryVoltage(log, voltage)
+			checkBatteryVoltage(log, voltage, current)
 		}
 
-		// Get unlock status
-		unlocked, err := fb.GetVar("unlocked")
-		if err != nil {
-			log.Tracef("Failed to get unlock status: %v", err)
+		if cErr != nil {
+			log.Tracef("Failed to get battery current: %v", cErr)
 		} else {
-			log.Infof("Unlock status: %s", unlocked)
+			checkBatteryCurrent(log, current)
 		}
 
 		fb.Close()
@@ -707,6 +705,9 @@ func displayFastbootInfo(log *logger.Logger, fb *tensorutils.Fastboot) {
 	}
 	if val, err := fb.GetVar("serialno"); err == nil {
 		log.Infof("Serial number: %s", val)
+	}
+	if speed := fb.GetSpeed(); speed != "" {
+		log.Infof("USB speed: %s", speed)
 	}
 
 	// Security state
@@ -748,22 +749,72 @@ func displayFastbootInfo(log *logger.Logger, fb *tensorutils.Fastboot) {
 		log.Infof("UART: %s", val)
 	}
 
+	// Battery info
+	if val, err := fb.GetVar("battery-voltage"); err == nil {
+		log.Infof("Battery voltage: %s", val)
+	}
+	if val, err := fb.GetVar("battery-current"); err == nil {
+		log.Infof("Battery current: %s", val)
+	}
+
 	log.Infoln("============================")
 }
 
 // checkBatteryVoltage parses voltage string and warns if below 4200mV
-func checkBatteryVoltage(log *logger.Logger, voltage string) {
+func checkBatteryVoltage(log *logger.Logger, voltage string, current string) {
 	// Parse voltage like "4292 mV" or "4292mV"
 	voltage = strings.TrimSpace(voltage)
 	voltage = strings.TrimSuffix(voltage, " mV")
 	voltage = strings.TrimSuffix(voltage, "mV")
 
+	// Parse current to check charging rate
+	currentStr := strings.TrimSpace(current)
+	currentStr = strings.TrimSuffix(currentStr, " mA")
+	currentStr = strings.TrimSuffix(currentStr, "mA")
+	var mA int
+	fmt.Sscanf(currentStr, "%d", &mA)
+
 	var mV int
 	if _, err := fmt.Sscanf(voltage, "%d", &mV); err == nil {
+		formatted := formatWithComma(mV)
 		if mV < 4200 {
-			log.Warnf("Battery at %dmV - keep waiting, need at least 4200mV for stable boot", mV)
+			log.Warnf("Battery at %smV - keep waiting, need at least 4,200mV for stable boot", formatted)
+			if mA < 600 {
+				log.Warnf("Charging slowly at %dmA - try a USB-C port or different cable for faster charging", mA)
+			}
+		} else if mA < 500 {
+			log.Infof("Battery at %smV - sufficient for boot (full charge may take up to 24 hours)", formatted)
 		} else {
-			log.Infof("Battery at %dmV - sufficient for boot (full charge may take up to 24 hours)", mV)
+			log.Infof("Battery at %smV - sufficient for boot (charging well, keep waiting for full charge)", formatted)
+		}
+	}
+}
+
+// formatWithComma formats an integer with comma separators
+func formatWithComma(n int) string {
+	s := fmt.Sprintf("%d", n)
+	if len(s) <= 3 {
+		return s
+	}
+	// Insert comma for thousands
+	return s[:len(s)-3] + "," + s[len(s)-3:]
+}
+
+// checkBatteryCurrent parses current string and warns if negative (discharging)
+func checkBatteryCurrent(log *logger.Logger, current string) {
+	// Parse current like "-106 mA" or "250mA"
+	current = strings.TrimSpace(current)
+	current = strings.TrimSuffix(current, " mA")
+	current = strings.TrimSuffix(current, "mA")
+
+	var mA int
+	if _, err := fmt.Sscanf(current, "%d", &mA); err == nil {
+		if mA < 0 {
+			log.Warnf("Battery current: %dmA - DISCHARGING! Device not charging properly, try a different USB port/cable", mA)
+		} else if mA == 0 {
+			log.Infof("Battery current: %dmA - not charging", mA)
+		} else {
+			log.Infof("Battery current: %dmA - charging", mA)
 		}
 	}
 }

--- a/dnw.go
+++ b/dnw.go
@@ -3,6 +3,7 @@ package tensorutils
 import (
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 	"time"
 
@@ -217,9 +218,10 @@ func (dnw *DNW) WriteMsg(msg *Message) error {
 	r.Seek(0, io.SeekEnd) //Seek to the end of the buffer to only process new responses after writing each block*/
 
 	//Write on loop until the end of message or error
-	blockSize := 10240
+	blockSize := 4096 // Smaller block size for stability
 	left := blockSize
 	wrote := 0
+	maxRetries := 5
 	for {
 		if dnw.Closed() {
 			return fmt.Errorf("dnw: closed but only wrote %d/%d bytes", wrote, len(p))
@@ -253,7 +255,27 @@ func (dnw *DNW) WriteMsg(msg *Message) error {
 			left -= (wrote + left) - len(p)
 		}
 
-		n, err := dnw.write(p[wrote : wrote+left])
+		// Retry loop for transient errors
+		var n int
+		var err error
+		for retry := 0; retry < maxRetries; retry++ {
+			n, err = dnw.write(p[wrote : wrote+left])
+			if err == nil {
+				break
+			}
+			errStr := strings.ToLower(err.Error())
+			isRetryable := strings.Contains(errStr, "interrupted") ||
+				strings.Contains(errStr, "timeout") ||
+				strings.Contains(errStr, "resource temporarily unavailable") ||
+				strings.Contains(errStr, "eagain") ||
+				strings.Contains(errStr, "busy")
+			if isRetryable {
+				fmt.Printf("dnw: write error at %d/%d bytes, retry %d/%d: %v\n", wrote+n, len(p), retry+1, maxRetries, err)
+				time.Sleep(time.Millisecond * 50)
+				continue
+			}
+			break // Non-retryable error
+		}
 		wrote += n
 		if err != nil {
 			return fmt.Errorf("dnw: failed to write after %d/%d bytes: %v", wrote, len(p), err)
@@ -266,7 +288,7 @@ func (dnw *DNW) WriteMsg(msg *Message) error {
 		return fmt.Errorf("dnw: only wrote %d/%d bytes", wrote, len(p))
 	}
 
-	time.Sleep(1)
+	time.Sleep(time.Millisecond * 1)
 	return nil
 }
 func (dnw *DNW) Write(p []byte) (int, error) {
@@ -284,7 +306,10 @@ func (dnw *DNW) write(p []byte) (int, error) {
 		return n, err
 	}
 	if err := dnw.port.Drain(); err != nil {
-		return n, err
+		// Drain errors are often transient, only fail on non-interrupted
+		if !strings.Contains(err.Error(), "interrupted") {
+			return n, err
+		}
 	}
 	return n, nil
 }
@@ -359,4 +384,13 @@ func (dnw *DNW) GetUSB() bool {
 		return false
 	}
 	return dnw.info.IsUSB
+}
+
+// Keepalive reads modem status bits to keep USB connection active
+func (dnw *DNW) Keepalive() error {
+	if dnw.Closed() {
+		return fmt.Errorf("dnw: closed")
+	}
+	_, err := dnw.port.GetModemStatusBits()
+	return err
 }

--- a/fastboot.go
+++ b/fastboot.go
@@ -25,6 +25,7 @@ type Fastboot struct {
 	in     *gousb.InEndpoint
 	out    *gousb.OutEndpoint
 	serial string
+	speed  string
 }
 
 // GetFastboot finds and opens a fastboot device by serial number
@@ -124,6 +125,7 @@ func GetFastboot(targetSerial string) (*Fastboot, error) {
 		in:     in,
 		out:    out,
 		serial: serial,
+		speed:  dev.Desc.Speed.String(),
 	}, nil
 }
 
@@ -238,6 +240,11 @@ func (fb *Fastboot) IsFlashing() bool {
 // GetSerial returns the device serial number
 func (fb *Fastboot) GetSerial() string {
 	return fb.serial
+}
+
+// GetSpeed returns the USB connection speed
+func (fb *Fastboot) GetSpeed() string {
+	return fb.speed
 }
 
 // Close releases all resources

--- a/fastboot.go
+++ b/fastboot.go
@@ -183,6 +183,51 @@ func (fb *Fastboot) readFinalResponse(timeout time.Duration) (string, error) {
 	}
 }
 
+// OemCommand sends an OEM command and returns all INFO responses
+func (fb *Fastboot) OemCommand(cmd string) ([]string, error) {
+	return fb.OemCommandWithTimeout(cmd, 5*time.Second)
+}
+
+// OemCommandWithTimeout sends an OEM command with a custom timeout
+func (fb *Fastboot) OemCommandWithTimeout(cmd string, timeout time.Duration) ([]string, error) {
+	fullCmd := fmt.Sprintf("oem %s", cmd)
+	_, err := fb.out.Write([]byte(fullCmd))
+	if err != nil {
+		return nil, fmt.Errorf("fastboot: write failed: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	var responses []string
+	for {
+		buf := make([]byte, 256)
+		n, err := fb.in.ReadContext(ctx, buf)
+		if err != nil {
+			return responses, fmt.Errorf("fastboot: read failed: %v", err)
+		}
+
+		resp := string(buf[:n])
+		if strings.HasPrefix(resp, "OKAY") {
+			return responses, nil
+		} else if strings.HasPrefix(resp, "FAIL") {
+			errMsg := strings.TrimPrefix(resp, "FAIL")
+			if errMsg == "" && len(responses) > 0 {
+				// Some commands return error details in INFO
+				return responses, fmt.Errorf("command failed")
+			}
+			return responses, fmt.Errorf("%s", errMsg)
+		} else if strings.HasPrefix(resp, "INFO") {
+			// Strip "INFO" prefix and collect the response
+			info := strings.TrimPrefix(resp, "INFO")
+			responses = append(responses, info)
+		} else {
+			// Unknown response type, include it anyway
+			responses = append(responses, resp)
+		}
+	}
+}
+
 // IsFlashing checks if device is busy (unresponsive to getvar)
 func (fb *Fastboot) IsFlashing() bool {
 	// Use short timeout - if device is flashing, it won't respond quickly

--- a/fastboot.go
+++ b/fastboot.go
@@ -1,0 +1,210 @@
+//go:build !nofastboot
+
+package tensorutils
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/gousb"
+)
+
+const (
+	GoogleVID    = 0x18d1
+	FastbootPID  = 0x4ee0
+	FastbootPID2 = 0xd00d
+)
+
+type Fastboot struct {
+	ctx    *gousb.Context
+	dev    *gousb.Device
+	intf   *gousb.Interface
+	done   func()
+	in     *gousb.InEndpoint
+	out    *gousb.OutEndpoint
+	serial string
+}
+
+// GetFastboot finds and opens a fastboot device by serial number
+func GetFastboot(targetSerial string) (*Fastboot, error) {
+	ctx := gousb.NewContext()
+
+	// Find device with matching VID/PID
+	var dev *gousb.Device
+	var err error
+
+	devs, err := ctx.OpenDevices(func(desc *gousb.DeviceDesc) bool {
+		if desc.Vendor == GoogleVID && (desc.Product == FastbootPID || desc.Product == FastbootPID2) {
+			return true
+		}
+		return false
+	})
+	if err != nil {
+		ctx.Close()
+		return nil, fmt.Errorf("fastboot: failed to enumerate devices: %v", err)
+	}
+
+	if len(devs) == 0 {
+		ctx.Close()
+		return nil, fmt.Errorf("fastboot: no device found")
+	}
+
+	// Find device with matching serial or use first if no serial specified
+	for _, d := range devs {
+		serial, _ := d.SerialNumber()
+		if targetSerial == "" || serial == targetSerial {
+			dev = d
+			break
+		}
+		d.Close()
+	}
+
+	// Close remaining devices
+	for _, d := range devs {
+		if d != dev {
+			d.Close()
+		}
+	}
+
+	if dev == nil {
+		ctx.Close()
+		return nil, fmt.Errorf("fastboot: device with serial %s not found", targetSerial)
+	}
+
+	serial, _ := dev.SerialNumber()
+
+	// Set auto-detach kernel driver
+	dev.SetAutoDetach(true)
+
+	// Claim interface 0 (fastboot)
+	intf, done, err := dev.DefaultInterface()
+	if err != nil {
+		dev.Close()
+		ctx.Close()
+		return nil, fmt.Errorf("fastboot: failed to claim interface: %v", err)
+	}
+
+	// Find bulk endpoints
+	var in *gousb.InEndpoint
+	var out *gousb.OutEndpoint
+	for _, ep := range intf.Setting.Endpoints {
+		if ep.Direction == gousb.EndpointDirectionIn {
+			in, err = intf.InEndpoint(ep.Number)
+			if err != nil {
+				done()
+				dev.Close()
+				ctx.Close()
+				return nil, fmt.Errorf("fastboot: failed to get IN endpoint: %v", err)
+			}
+		} else {
+			out, err = intf.OutEndpoint(ep.Number)
+			if err != nil {
+				done()
+				dev.Close()
+				ctx.Close()
+				return nil, fmt.Errorf("fastboot: failed to get OUT endpoint: %v", err)
+			}
+		}
+	}
+
+	if in == nil || out == nil {
+		done()
+		dev.Close()
+		ctx.Close()
+		return nil, fmt.Errorf("fastboot: endpoints not found")
+	}
+
+	return &Fastboot{
+		ctx:    ctx,
+		dev:    dev,
+		intf:   intf,
+		done:   done,
+		in:     in,
+		out:    out,
+		serial: serial,
+	}, nil
+}
+
+// GetVar sends "getvar:name" and returns the value
+func (fb *Fastboot) GetVar(name string) (string, error) {
+	return fb.GetVarWithTimeout(name, 5*time.Second)
+}
+
+// GetVarWithTimeout sends "getvar:name" with a custom timeout
+func (fb *Fastboot) GetVarWithTimeout(name string, timeout time.Duration) (string, error) {
+	cmd := fmt.Sprintf("getvar:%s", name)
+	_, err := fb.out.Write([]byte(cmd))
+	if err != nil {
+		return "", fmt.Errorf("fastboot: write failed: %v", err)
+	}
+
+	// Read response with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	buf := make([]byte, 256)
+	n, err := fb.in.ReadContext(ctx, buf)
+	if err != nil {
+		return "", fmt.Errorf("fastboot: read failed: %v", err)
+	}
+
+	resp := string(buf[:n])
+	if strings.HasPrefix(resp, "OKAY") {
+		return strings.TrimPrefix(resp, "OKAY"), nil
+	} else if strings.HasPrefix(resp, "FAIL") {
+		return "", fmt.Errorf("%s", strings.TrimPrefix(resp, "FAIL"))
+	} else if strings.HasPrefix(resp, "INFO") {
+		// INFO responses are informational, try to read the final OKAY/FAIL
+		return fb.readFinalResponse(timeout)
+	}
+	return resp, nil
+}
+
+// readFinalResponse reads until OKAY or FAIL after INFO messages
+func (fb *Fastboot) readFinalResponse(timeout time.Duration) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	for {
+		buf := make([]byte, 256)
+		n, err := fb.in.ReadContext(ctx, buf)
+		if err != nil {
+			return "", err
+		}
+		resp := string(buf[:n])
+		if strings.HasPrefix(resp, "OKAY") {
+			return strings.TrimPrefix(resp, "OKAY"), nil
+		} else if strings.HasPrefix(resp, "FAIL") {
+			return "", fmt.Errorf("%s", strings.TrimPrefix(resp, "FAIL"))
+		}
+		// Continue reading if it's another INFO
+	}
+}
+
+// IsFlashing checks if device is busy (unresponsive to getvar)
+func (fb *Fastboot) IsFlashing() bool {
+	// Use short timeout - if device is flashing, it won't respond quickly
+	_, err := fb.GetVarWithTimeout("product", 500*time.Millisecond)
+	return err != nil
+}
+
+// GetSerial returns the device serial number
+func (fb *Fastboot) GetSerial() string {
+	return fb.serial
+}
+
+// Close releases all resources
+func (fb *Fastboot) Close() error {
+	if fb.done != nil {
+		fb.done()
+	}
+	if fb.dev != nil {
+		fb.dev.Close()
+	}
+	if fb.ctx != nil {
+		fb.ctx.Close()
+	}
+	return nil
+}

--- a/fastboot.go
+++ b/fastboot.go
@@ -247,6 +247,55 @@ func (fb *Fastboot) GetSpeed() string {
 	return fb.speed
 }
 
+// Reboot sends the reboot command to restart the device
+func (fb *Fastboot) Reboot() error {
+	return fb.sendCommand("reboot", 5*time.Second)
+}
+
+// PowerOff sends the powerdown command to shut off the device
+func (fb *Fastboot) PowerOff() error {
+	return fb.sendCommand("powerdown", 5*time.Second)
+}
+
+// sendCommand sends a command and waits for OKAY/FAIL response
+func (fb *Fastboot) sendCommand(cmd string, timeout time.Duration) error {
+	_, err := fb.out.Write([]byte(cmd))
+	if err != nil {
+		return fmt.Errorf("fastboot: write failed: %v", err)
+	}
+
+	// Read response with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	buf := make([]byte, 256)
+	n, err := fb.in.ReadContext(ctx, buf)
+	if err != nil {
+		return fmt.Errorf("fastboot: read failed: %v", err)
+	}
+
+	resp := string(buf[:n])
+	if strings.HasPrefix(resp, "OKAY") {
+		return nil
+	} else if strings.HasPrefix(resp, "FAIL") {
+		return fmt.Errorf("%s", strings.TrimPrefix(resp, "FAIL"))
+	}
+	return nil
+}
+
+// FlashingUnlock sends the flashing unlock command (Pixel standard)
+func (fb *Fastboot) FlashingUnlock() error {
+	return fb.sendCommand("flashing unlock", 10*time.Second)
+}
+
+// Reset performs a USB device reset
+func (fb *Fastboot) Reset() error {
+	if fb.dev == nil {
+		return fmt.Errorf("fastboot: device not open")
+	}
+	return fb.dev.Reset()
+}
+
 // Close releases all resources
 func (fb *Fastboot) Close() error {
 	if fb.done != nil {

--- a/fastboot.go
+++ b/fastboot.go
@@ -296,6 +296,14 @@ func (fb *Fastboot) Reset() error {
 	return fb.dev.Reset()
 }
 
+// GetBusAddr returns the USB bus number and device address
+func (fb *Fastboot) GetBusAddr() (int, int) {
+	if fb.dev == nil {
+		return 0, 0
+	}
+	return fb.dev.Desc.Bus, fb.dev.Desc.Address
+}
+
 // Close releases all resources
 func (fb *Fastboot) Close() error {
 	if fb.done != nil {

--- a/fastboot_stub.go
+++ b/fastboot_stub.go
@@ -21,6 +21,14 @@ func (fb *Fastboot) GetVarWithTimeout(name string, timeout time.Duration) (strin
 	return "", fmt.Errorf("fastboot not available")
 }
 
+func (fb *Fastboot) OemCommand(cmd string) ([]string, error) {
+	return nil, fmt.Errorf("fastboot not available")
+}
+
+func (fb *Fastboot) OemCommandWithTimeout(cmd string, timeout time.Duration) ([]string, error) {
+	return nil, fmt.Errorf("fastboot not available")
+}
+
 func (fb *Fastboot) IsFlashing() bool {
 	return false
 }

--- a/fastboot_stub.go
+++ b/fastboot_stub.go
@@ -1,0 +1,34 @@
+//go:build nofastboot
+
+package tensorutils
+
+import (
+	"fmt"
+	"time"
+)
+
+type Fastboot struct{}
+
+func GetFastboot(targetSerial string) (*Fastboot, error) {
+	return nil, fmt.Errorf("fastboot support disabled (built with -tags nofastboot)")
+}
+
+func (fb *Fastboot) GetVar(name string) (string, error) {
+	return "", fmt.Errorf("fastboot not available")
+}
+
+func (fb *Fastboot) GetVarWithTimeout(name string, timeout time.Duration) (string, error) {
+	return "", fmt.Errorf("fastboot not available")
+}
+
+func (fb *Fastboot) IsFlashing() bool {
+	return false
+}
+
+func (fb *Fastboot) GetSerial() string {
+	return ""
+}
+
+func (fb *Fastboot) Close() error {
+	return nil
+}

--- a/fastboot_stub.go
+++ b/fastboot_stub.go
@@ -57,6 +57,10 @@ func (fb *Fastboot) Reset() error {
 	return fmt.Errorf("fastboot not available")
 }
 
+func (fb *Fastboot) GetBusAddr() (int, int) {
+	return 0, 0
+}
+
 func (fb *Fastboot) Close() error {
 	return nil
 }

--- a/fastboot_stub.go
+++ b/fastboot_stub.go
@@ -37,6 +37,10 @@ func (fb *Fastboot) GetSerial() string {
 	return ""
 }
 
+func (fb *Fastboot) GetSpeed() string {
+	return ""
+}
+
 func (fb *Fastboot) Close() error {
 	return nil
 }

--- a/fastboot_stub.go
+++ b/fastboot_stub.go
@@ -41,6 +41,22 @@ func (fb *Fastboot) GetSpeed() string {
 	return ""
 }
 
+func (fb *Fastboot) Reboot() error {
+	return fmt.Errorf("fastboot not available")
+}
+
+func (fb *Fastboot) PowerOff() error {
+	return fmt.Errorf("fastboot not available")
+}
+
+func (fb *Fastboot) FlashingUnlock() error {
+	return fmt.Errorf("fastboot not available")
+}
+
+func (fb *Fastboot) Reset() error {
+	return fmt.Errorf("fastboot not available")
+}
+
 func (fb *Fastboot) Close() error {
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require go.bug.st/serial v1.6.2
 require (
 	github.com/JoshuaDoes/crunchio v0.0.4 // indirect
 	github.com/JoshuaDoes/logger v0.0.1 // indirect
+	github.com/google/gousb v1.1.3 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/creack/goselect v0.1.2/go.mod h1:a/NhLweNvqIYMuxcMOuWY516Cimucms3DglD
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/gousb v1.1.3 h1:xt6M5TDsGSZ+rlomz5Si5Hmd/Fvbmo2YCJHN+yGaK4o=
+github.com/google/gousb v1.1.3/go.mod h1:GGWUkK0gAXDzxhwrzetW592aOmkkqSGcj5KLEgmCVUg=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=


### PR DESCRIPTION
## Summary

- Add fastboot protocol support for post-EUB device monitoring
- Display battery voltage and current with formatted output (e.g., `4,302mV @ 1,123mA`)
- Show human-readable USB speed with max charging capability
- Warn when device is discharging with clear replug instructions
- Add OEM command support for GSC queries
- Detect device state and attempt unlock when unbricking succeeds
- Optional build without fastboot via `-tags nofastboot` (no libusb dependency)

## Features

### Battery Monitoring
- Real-time voltage/current display during fastboot
- Charging rate assessment with warnings for slow charging
- Detection of discharging state with manual replug prompt
- Monitoring loop with 1-minute intervals

### USB Speed Display
Shows connection speed and max charging current:
- USB 2.0 Full Speed (12 Mbps, max 500mA)
- USB 2.0 High Speed (480 Mbps, max 500mA)  
- USB 3.0 SuperSpeed (5 Gbps, max 900mA)
- USB 3.1 SuperSpeed+ (10 Gbps, max 900mA)

### New CLI Flags
- `--fastboot` - Skip EUB, monitor fastboot device directly
- `--serial` - Specify fastboot device serial

## Test plan
- [x] Build with fastboot support (default)
- [x] Build without fastboot (`-tags nofastboot`)
- [x] Test battery monitoring on Pixel 7a in fastboot mode
- [x] Verify formatted number output for 4-digit values
- [x] Verify negative current values display correctly