### PR TITLE
Update operation values for bootloader cases

### DIFF
--- a/cmd/tensor-usbdl/main.go
+++ b/cmd/tensor-usbdl/main.go
@@ -375,7 +375,10 @@ func main() {
 					op = 0
 				case "EPBL":
 					bl = bootloaders["PBL"]
-					op = 0
+					op = 1
+				case "EPBB":
+					bl = bootloaders["PBL"]
+					op = 2
 				case "BL2":
 					bl = bootloaders["BL2"]
 					op = 1


### PR DESCRIPTION
After modifying the code, I was able to use it on my Pixel 8.


# Before
<img width="1711" height="994" alt="BeforeProblem" src="https://github.com/user-attachments/assets/1d1c6cc4-e59e-4561-9a0c-218b33e8c030" />

# After
<img width="1686" height="1992" alt="AfterFix" src="https://github.com/user-attachments/assets/ae381ed6-4cf8-4d5c-8bf3-29a83e14e64f" />
<img width="1696" height="2009" alt="2026-02-25 15 10 17" src="https://github.com/user-attachments/assets/5fea8492-a5c6-4689-aa6a-fde39d0b791f" />
<img width="1710" height="297" alt="AfterFix2" src="https://github.com/user-attachments/assets/55b74ae0-8ee4-4964-830d-5620ef5ae141" />
